### PR TITLE
fix for the speed reset maybe ?

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,57 +1,6 @@
-local g_playersNoChar = {}
-
-function update_player(p_player)
-  p_player.character_crafting_speed_modifier = settings.global["speed-settings-player-crafting"].value
-  p_player.character_mining_speed_modifier = settings.global["speed-settings-player-mining"].value
-  p_player.character_running_speed_modifier = settings.global["speed-settings-player-running"].value
+function update_game_speed()
+    game.speed = settings.global["speed-settings-game"].value
 end
 
-function update_player_force()
-  game.forces["player"].laboratory_speed_modifier = settings.global["speed-settings-force-lab"].value
-  game.forces["player"].worker_robots_speed_modifier = settings.global["speed-settings-force-worker-robot"].value
-end
-
-function update_speed_settings()
-  game.speed = settings.global["speed-settings-game"].value
-
-  -- Update all players that have a character associated with them.
-  for _, e_player in pairs(game.players) do
-    if (e_player.character) then
-      update_player(e_player)
-    end
-  end
-
-  update_player_force()
-end
-
-function wait_for_char_creation()
-  -- Keep this handler active until all players have a character.
-  if #g_playersNoChar > 0 then
-    -- For every player on the waiting list.
-    for i, e_playerIndex in ipairs(g_playersNoChar) do
-      -- Update the player if a character has been created and remove the player from the waiting list.
-      if game.players[e_playerIndex].character then
-        update_player(game.players[e_playerIndex])
-        table.remove(g_playersNoChar, i)
-      end
-    end
-  else
-    -- Deactive this handler if the waiting list is empty.
-    script.on_event(defines.events.on_tick, nil)
-  end
-end
-
--- Update the speed settings on save creation.
-script.on_init(update_speed_settings)
-
--- Apparently, players do not have an associated character on creation. Therefore, I decided to poll for the creation of
--- new characters. I'm not sure if I overlooked something in the API docs, but a more elegant solution will be
--- appreciated (preferably an event that's raised whenever a player character is created).
-script.on_event(defines.events.on_player_created, function(p_data)
-  table.insert(g_playersNoChar, p_data.player_index)
-
-  script.on_event(defines.events.on_tick, wait_for_char_creation)
-end)
-
--- Update the speed settings after it was changed.
-script.on_event(defines.events.on_runtime_mod_setting_changed, update_speed_settings)
+script.on_init(update_game_speed)
+script.on_event(defines.events.on_runtime_mod_setting_changed, update_game_speed)

--- a/data.lua
+++ b/data.lua
@@ -1,0 +1,11 @@
+data.raw["lab"]["lab"].researching_speed = data.raw["lab"]["lab"].researching_speed * settings.startup["speed-settings-lab"].value
+if mods["space-age"] then
+    data.raw["lab"]["biolab"].researching_speed = data.raw["lab"]["biolab"].researching_speed * settings.startup["speed-settings-lab"].value
+end
+
+data.raw["construction-robot"]["construction-robot"].speed = data.raw["construction-robot"]["construction-robot"].speed * settings.startup["speed-settings-worker-robot"].value
+data.raw["logistic-robot"]["logistic-robot"].speed = data.raw["logistic-robot"]["logistic-robot"].speed * settings.startup["speed-settings-worker-robot"].value
+
+data.raw["character"]["character"].crafting_speed = settings.startup["speed-settings-player-crafting"].value
+data.raw["character"]["character"].mining_speed = data.raw["character"]["character"].mining_speed * settings.startup["speed-settings-player-mining"].value
+data.raw["character"]["character"].running_speed = data.raw["character"]["character"].running_speed * settings.startup["speed-settings-player-running"].value

--- a/info.json
+++ b/info.json
@@ -1,7 +1,11 @@
 {
   "name": "speed-settings",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "title": "Speed Settings",
+  "dependencies": [
+    "base >= 2.0.0",
+    "?space-age"
+  ],
   "author": "Diordany van Hemert",
   "homepage": "https://github.com/Diordany/factorio-speed-settings",
   "description": "Adds the ability to configure the following speeds in the mod settings: game speed; player running speed; player mining speed; player crafting speed; worker robot speed; research lab speed.\n\nWARNING: keep in mind that a higher game speed will be more demanding for your system!",

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1,15 +1,15 @@
 [mod-setting-name]
-speed-settings-force-lab=Additional Lab Speed
-speed-settings-force-worker-robot=Additional Worker Robot Speed
+speed-settings-lab=Lab Speed
+speed-settings-worker-robot=Worker Robot Speed
 speed-settings-game=Game Speed
-speed-settings-player-crafting=Additional Player Crafting Speed
-speed-settings-player-mining=Additional Player Mining Speed
-speed-settings-player-running=Additional Player Running Speed
+speed-settings-player-crafting=Player Crafting Speed
+speed-settings-player-mining=Player Mining Speed
+speed-settings-player-running=Player Running Speed
 
 [mod-setting-description]
-speed-settings-force-lab=Set additional speed for the research labs that belong to the player force. The minimum value is -1.0 (corresponding to -100 % of the base speed).
-speed-settings-force-worker-robot=Set additional speed for the worker robots that belong to the player force. The minimum value is -1.0 (corresponding to -100 % of the base speed).
+speed-settings-lab=Set the multiplier for the lab speed, 2.0 means they are twice as fast.
+speed-settings-worker-robot=Set the multiplier for the worker robots speed, 2.0 means they are twice as fast.
 speed-settings-game=Sets the game speed factor. The minimum value is 0.1.\n\nWARNING: keep in mind that a higher game speed will be more demanding for your system!
-speed-settings-player-crafting=Give the player additional crafting speed. The minimum value is -1.0 (corresponding to -100 % of the base speed).
-speed-settings-player-mining=Give the player additional mining speed. The minimum value is -1.0 (corresponding to -100 % of the base speed).
-speed-settings-player-running=Give the player additional running speed. The minimum value is -1.0 (corresponding to -100 % of the base speed).
+speed-settings-player-crafting=Set the multiplier for player crafting speed, 2.0 means it is twice as fast.
+speed-settings-player-mining=Set the multiplier for the player mining speed, 2.0 means it is twice as fast.
+speed-settings-player-running=Set the multiplier for the player running speed, 2.0 means it is twice as fast.

--- a/settings.lua
+++ b/settings.lua
@@ -1,19 +1,19 @@
 data:extend({
   {
     type = "double-setting",
-    name = "speed-settings-force-lab",
+    name = "speed-settings-lab",
     order = "cb",
-    setting_type = "runtime-global",
-    default_value = 0.0,
-    minimum_value = -1.0
+    setting_type = "startup",
+    default_value = 1.0,
+    minimum_value = 0.1
   },
   {
     type = "double-setting",
-    name = "speed-settings-force-worker-robot",
+    name = "speed-settings-worker-robot",
     order = "ca",
-    setting_type = "runtime-global",
-    default_value = 0.0,
-    minimum_value = -1.0
+    setting_type = "startup",
+    default_value = 1.0,
+    minimum_value = 0.1
   },
   {
     type = "double-setting",
@@ -27,24 +27,24 @@ data:extend({
     type = "double-setting",
     name = "speed-settings-player-crafting",
     order = "bc",
-    setting_type = "runtime-global",
-    default_value = 0.0,
-    minimum_value = -1.0
+    setting_type = "startup",
+    default_value = 1.0,
+    minimum_value = 0.1
   },
   {
     type = "double-setting",
     name = "speed-settings-player-mining",
     order = "bb",
-    setting_type = "runtime-global",
-    default_value = 0.0,
-    minimum_value = -1.0
+    setting_type = "startup",
+    default_value = 1.0,
+    minimum_value = 0.1
   },
   {
     type = "double-setting",
     name = "speed-settings-player-running",
     order = "ba",
-    setting_type = "runtime-global",
-    default_value = 0.0,
-    minimum_value = -1.0
+    setting_type = "startup",
+    default_value = 1.0,
+    minimum_value = 0.1
   }
 })


### PR DESCRIPTION
Here's my suggestion for a potential fix. I moved every settings except game speed to startup settings and modified the prototype of the associated entities. Because it is changing the base values, it should not affect the bonuses anymore.