### PR TITLE
Fix that allows to change the speed bonus in real time

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -6,10 +6,6 @@ function update_player(p_player)
   p_player.character_running_speed_modifier = settings.global["speed-settings-player-running"].value
 end
 
-function update_base_speed_tracker(old_value, new_value, mod_bonus)
-  return 
-end
-
 function update_player_force()
   -- For update, we simply add the difference between the current and previous setting
   local laboratory_bonus_delta = settings.global["speed-settings-force-lab"].value - storage["speed-settings-previous-laboratory-bonus"]


### PR DESCRIPTION
The way this fix works is that it simply apply the difference between the previous speed settings and the current one. I am worried about double float precision that would make drift the value in certain scenarios but I think the overall principle is sound.